### PR TITLE
Publish and deploy release to Maven Central with JReleaser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,12 +55,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          server-id: central
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_CENTRAL_TOKEN
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-          cache: maven
       - name: Build
         run: ./gradlew publish jreleaserFullRelease
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build and Test
 on:
   push:
     branches: ["main"]
+    tags:
+      - '*'
   pull_request:
     branches: ["main"]
 
@@ -40,12 +42,33 @@ jobs:
       - name: Run UI Tests
         run: ./gradlew sampleapp:pixel5api34DebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
 
-# TODO: Publishing to come later
-  # build_kherkin:
-  #   name: Build Kherkin
+  publish_release:
+    name: Publish Release
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: [run_tests]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          cache: maven
+      - name: Build
+        run: ./gradlew publish jreleaserFullRelease
+
+  # publish_snapshot:
+  #   name: Publish Snapshot
+  #   if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
   #   runs-on: ubuntu-latest
   #   needs: [run_tests]
-  #   # if publish selected
   #   steps:
   #     - name: Checkout
   #       uses: actions/checkout@v4
@@ -54,6 +77,11 @@ jobs:
   #       with:
   #         java-version: '17'
   #         distribution: 'temurin'
-  #     - name: Build
-  #       run: ./gradlew assembleRelease --stacktrace
-  #       # publish snapshot here?
+  #         server-id: central
+  #         server-username: MAVEN_USERNAME
+  #         server-password: MAVEN_CENTRAL_TOKEN
+  #         gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+  #         gpg-passphrase: MAVEN_GPG_PASSPHRASE
+  #         cache: maven
+  #     - name: Publish
+  #       run: ./gradlew publish -PversionName=$(git describe)-SNAPSHOT -PmySecureRepositoryUsername=secret-user -PmySecureRepositoryPassword=secret-password

--- a/build-conventions/build.gradle
+++ b/build-conventions/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'groovy-gradle-plugin'
+}

--- a/build-conventions/settings.gradle
+++ b/build-conventions/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'build-conventions'

--- a/build-conventions/src/main/groovy/Kherkin.sharedPublish.gradle
+++ b/build-conventions/src/main/groovy/Kherkin.sharedPublish.gradle
@@ -52,7 +52,18 @@ android {
     }
 }
 
+tasks.register('prepareDirs') {
+    mustRunAfter clean
+    doLast {
+        mkdir "build/staging-deploy"
+    }
+}
+
 afterEvaluate {
+    tasks.withType(PublishToMavenRepository).configureEach {
+        dependsOn(tasks.prepareDirs)
+    }
+
     publishing {
         publications {
             publishLibrary(MavenPublication) {
@@ -112,7 +123,7 @@ jreleaser {
                 sonatype {
                     active = 'ALWAYS'
                     url = 'https://central.sonatype.com/api/v1/publisher'
-                    stagingRepository('target/staging-deploy')
+                    stagingRepository('build/staging-deploy')
                 }
             }
         }

--- a/build-conventions/src/main/groovy/Kherkin.sharedPublish.gradle
+++ b/build-conventions/src/main/groovy/Kherkin.sharedPublish.gradle
@@ -1,0 +1,120 @@
+plugins {
+    id 'com.android.library'
+    id 'maven-publish'
+    id 'org.jreleaser'
+}
+
+def getVersionName = { ->
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'describe', '--exact-match', 'HEAD'
+            standardOutput = stdout
+        }
+        return stdout.toString().trim()
+    }
+    catch (ignored) {
+        return null
+    }
+}
+
+android {
+    compileSdk 34
+    version getVersionName()
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
+
+    defaultConfig {
+        minSdk 24
+        targetSdk 34
+        versionName getVersionName()
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            publishLibrary(MavenPublication) {
+                groupId 'com.progressive.kherkin'
+                artifactId ARTIFACT_ID
+
+                afterEvaluate {
+                    from components.release
+                }
+
+                pom {
+                    name = ARTIFACT_ID
+                    description = DESCRIPTION
+                    url = 'https://github.com/Progressive-Insurance/kherkin'
+                    inceptionYear = '2024'
+
+                    licenses {
+                        license {
+                            name = 'MIT License'
+                            url = 'http://www.opensource.org/licenses/mit-license.php'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            name = 'Matthew Rockwell'
+                            email = 'smugleafdev@gmail.com'
+                        }
+                    }
+
+                    scm {
+                        connection = 'scm:git:https://github.com/Progressive-Insurance/kherkin.git'
+                        developerConnection = 'scm:git:ssh://github.com/Progressive-Insurance/kherkin.git'
+                        url = 'http://github.com/Progressive-Insurance/kherkin'
+                    }
+                }
+            }
+        }
+
+        repositories {
+            maven {
+                url = layout.buildDirectory.dir('staging-deploy')
+            }
+        }
+    }
+}
+
+jreleaser {
+    gitRootSearch = true
+    signing {
+        active = 'ALWAYS'
+        armored = true
+    }
+    deploy {
+        maven {
+            mavenCentral {
+                sonatype {
+                    active = 'ALWAYS'
+                    url = 'https://central.sonatype.com/api/v1/publisher'
+                    stagingRepository('target/staging-deploy')
+                }
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     alias libs.plugins.com.android.library apply false
     alias libs.plugins.compose.compiler apply false
     alias libs.plugins.kotlin.android apply false
-    alias libs.plugins.jfrog apply false
+    alias libs.plugins.jreleaser apply false
 }
 
 allprojects {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -6,57 +6,18 @@ buildscript {
 }
 
 plugins {
-    alias libs.plugins.jfrog
     alias libs.plugins.com.android.library
     alias libs.plugins.kotlin.android
-    id 'maven-publish'
+    id 'Kherkin.sharedPublish'
 }
 
-def getVersionName = { ->
-    try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'describe', '--always'
-            standardOutput = stdout
-        }
-        return stdout.toString().trim()
-    }
-    catch (ignored) {
-        return null
-    }
+ext {
+    ARTIFACT_ID = "kherkin-common"
+    DESCRIPTION = "A dependency for kherkin-espresso and kherkin-compose"
 }
 
 android {
     namespace 'com.progressive.kherkin.common'
-    compileSdk 34
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
-
-    defaultConfig {
-        minSdk 24
-        targetSdk 34
-        versionName getVersionName()
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled false
-        }
-    }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = '17'
-    }
 }
 
 dependencies {
@@ -73,23 +34,4 @@ dependencies {
     api libs.kotlin.test
     api libs.androidx.rules
     api libs.kotlin.reflect
-}
-
-
-publishing {
-    publications {
-        aarCommon(MavenPublication) {
-            groupId 'com.progressive.kherkin'
-            artifactId 'kherkin-common'
-            version android.defaultConfig.versionName
-
-            afterEvaluate {
-                from components.release
-            }
-        }
-    }
-}
-
-artifactoryPublish {
-    publications(publishing.publications.aarCommon)
 }

--- a/compose/build.gradle
+++ b/compose/build.gradle
@@ -6,56 +6,18 @@ buildscript {
 }
 
 plugins {
-    alias libs.plugins.jfrog
     alias libs.plugins.com.android.library
     alias libs.plugins.kotlin.android
-    id 'maven-publish'
+    id 'Kherkin.sharedPublish'
 }
 
-def getVersionName = { ->
-    try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'describe', '--always'
-            standardOutput = stdout
-        }
-        return stdout.toString().trim()
-    }
-    catch (ignored) {
-        return null
-    }
+ext {
+    ARTIFACT_ID = "kherkin-compose"
+    DESCRIPTION = "An Android UI testing framework for Jetpack Compose screens that simplifies writing UI tests"
 }
 
 android {
     namespace 'com.progressive.kherkin.compose'
-    compileSdk 34
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
-
-    defaultConfig {
-        minSdk 24
-        targetSdk 34
-        versionName getVersionName()
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled false
-        }
-    }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = '17'
-    }
 }
 
 dependencies {
@@ -69,22 +31,4 @@ dependencies {
     api(libs.compose.test)
     api(libs.compose.testing)
     api(project(':common'))
-}
-
-publishing {
-    publications {
-        aarCompose(MavenPublication) {
-            groupId 'com.progressive.kherkin'
-            artifactId 'kherkin-compose'
-            version android.defaultConfig.versionName
-
-            afterEvaluate {
-                from components.release
-            }
-        }
-    }
-}
-
-artifactoryPublish {
-    publications(publishing.publications.aarCompose)
 }

--- a/espresso/build.gradle
+++ b/espresso/build.gradle
@@ -6,56 +6,18 @@ buildscript {
 }
 
 plugins {
-    alias libs.plugins.jfrog
     alias libs.plugins.com.android.library
     alias libs.plugins.kotlin.android
-    id 'maven-publish'
+    id 'Kherkin.sharedPublish'
 }
 
-def getVersionName = { ->
-    try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'describe', '--always'
-            standardOutput = stdout
-        }
-        return stdout.toString().trim()
-    }
-    catch (ignored) {
-        return null
-    }
+ext {
+    ARTIFACT_ID = "kherkin-espresso"
+    DESCRIPTION = "An Android UI testing framework for XML layouts that simplifies writing UI tests"
 }
 
 android {
     namespace 'com.progressive.kherkin.espresso'
-    compileSdk 34
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
-
-    defaultConfig {
-        minSdk 24
-        targetSdk 34
-        versionName getVersionName()
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled false
-        }
-    }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = '17'
-    }
 }
 
 dependencies {
@@ -67,22 +29,4 @@ dependencies {
     api(libs.espresso.core)
     api(libs.espresso.contrib)
     api(project(':common'))
-}
-
-publishing {
-    publications {
-        aarEspresso(MavenPublication) {
-            groupId 'com.progressive.kherkin'
-            artifactId 'kherkin-espresso'
-            version android.defaultConfig.versionName
-
-            afterEvaluate {
-                from components.release
-            }
-        }
-    }
-}
-
-artifactoryPublish {
-    publications(publishing.publications.aarEspresso)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,3 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,3 @@ android.enableJetifier=true
 kotlin.code.style=official
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
-org.gradle.warning.mode=all

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ espresso = "3.6.1"
 findbugs = "3.0.2"
 fragmentKtx = "1.8.5"
 javaxInject = "1"
-jfrogGradle = "4.24.16"
+jreleaser = "1.16.0"
 junit = "4.13.2"
 kotlin = "2.0.21"
 lifecycleViewmodelKtx = "2.8.7"
@@ -56,5 +56,5 @@ viewbinding = { module = "com.android.databinding:viewbinding", version.ref = "v
 com-android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 com-android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-jfrog = { id = "com.jfrog.artifactory", version.ref = "jfrogGradle" }
+jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,8 @@ pluginManagement {
 }
 
 rootProject.name = 'Kherkin'
+
+includeBuild 'build-conventions'
 include ':sampleapp'
 include ':compose'
 include ':espresso'


### PR DESCRIPTION
Use the [JReleaser Gradle Plugin](https://jreleaser.org/guide/latest/examples/maven/maven-central.html) to prepare artifacts and publish to Maven Central.

Note: Intended for tagged releases only, snapshots to come later.