### PR TITLE
Small fixes for publishing with Jreleaser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,12 +50,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: 'true'
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Build
+      - name: Build and deploy
         run: ./gradlew publish jreleaserFullRelease
 
   # publish_snapshot:

--- a/build-conventions/src/main/groovy/Kherkin.sharedPublish.gradle
+++ b/build-conventions/src/main/groovy/Kherkin.sharedPublish.gradle
@@ -56,6 +56,7 @@ tasks.register('prepareDirs') {
     mustRunAfter clean
     doLast {
         mkdir "build/staging-deploy"
+        mkdir "build/jreleaser"
     }
 }
 


### PR DESCRIPTION
Tags are not fetched with default checkout task

Jreleaser wants a mysterious /build/jreleaser/ directory and their documentation did not say so anywhere and I had to learn through the failure of my first release attempt