### PR TITLE
Release broken #4: Add tags argument to git describe to make semver release work

### DIFF
--- a/build-conventions/src/main/groovy/Kherkin.sharedPublish.gradle
+++ b/build-conventions/src/main/groovy/Kherkin.sharedPublish.gradle
@@ -8,7 +8,7 @@ def getVersionName = { ->
     try {
         def stdout = new ByteArrayOutputStream()
         exec {
-            commandLine 'git', 'describe', '--exact-match', 'HEAD'
+            commandLine 'git', 'describe', '--tags', '--exact-match', 'HEAD'
             standardOutput = stdout
         }
         return stdout.toString().trim()


### PR DESCRIPTION
commandLine 'git', 'describe', '--tags', '--exact-match', 'HEAD'

That's it. That's the whole thing.