### PR TITLE
Add pressImeAction to compose text field steps, fix typo

### DIFF
--- a/compose/src/main/java/com/progressive/kherkin/compose/steps/actions/ScrollSteps.kt
+++ b/compose/src/main/java/com/progressive/kherkin/compose/steps/actions/ScrollSteps.kt
@@ -8,11 +8,11 @@ import androidx.compose.ui.test.performScrollToNode
 import com.progressive.kherkin.common.testcore.Gherkin
 
  /** Scrolls a scrollable container [tagOfScrollableContainer] to the matching [tag]. */
-fun Gherkin.IScrollOnNodeUntillISee(tagOfScrollableContainer: String, tag: String, composeTestRule: ComposeTestRule) {
+fun Gherkin.IScrollOnNodeUntilISee(tagOfScrollableContainer: String, tag: String, composeTestRule: ComposeTestRule) {
     composeTestRule.onNodeWithTag(tagOfScrollableContainer).performScrollToNode(hasTestTag(tag))
 }
 
 /** Scrolls a scrollable container [tagOfScrollableContainer] to the matching [text]. */
-fun Gherkin.IScrollOnNodeUntillISeeText(tagOfScrollableContainer: String, text: String, composeTestRule: ComposeTestRule) {
+fun Gherkin.IScrollOnNodeUntilISeeText(tagOfScrollableContainer: String, text: String, composeTestRule: ComposeTestRule) {
     composeTestRule.onNodeWithTag(tagOfScrollableContainer).performScrollToNode(hasText(text))
 }

--- a/compose/src/main/java/com/progressive/kherkin/compose/steps/actions/TextFieldSteps.kt
+++ b/compose/src/main/java/com/progressive/kherkin/compose/steps/actions/TextFieldSteps.kt
@@ -12,6 +12,7 @@ import com.progressive.kherkin.common.testcore.Gherkin
 /** Finds a node with [tag] and inputs [text] into the text field. */
 fun Gherkin.IEnterTextIntoField(tag: String, text: String, composeTestRule: ComposeTestRule) {
     composeTestRule.onNodeWithTag(tag).assert(hasSetTextAction()).performTextInput(text)
+    composeTestRule.onNodeWithTag(tag).assert(hasSetTextAction()).performImeAction()
 }
 
 /** Finds a node with [tag] and leaves the text field empty. */
@@ -22,4 +23,5 @@ fun Gherkin.ILeaveFieldEmpty(tag: String, composeTestRule: ComposeTestRule) {
 /** Finds a node with [tag] and clears the text field. */
 fun Gherkin.IClearField(tag: String, composeTestRule: ComposeTestRule) {
     composeTestRule.onNodeWithTag(tag).assert(hasSetTextAction()).performTextClearance()
+    composeTestRule.onNodeWithTag(tag).assert(hasSetTextAction()).performImeAction()
 }

--- a/sampleapp/src/androidTest/java/com/progressive/sampleapp/tests/compose/TestScrollSteps.kt
+++ b/sampleapp/src/androidTest/java/com/progressive/sampleapp/tests/compose/TestScrollSteps.kt
@@ -3,8 +3,8 @@ package com.progressive.sampleapp.tests.compose
 import com.progressive.kherkin.common.testcore.Given
 import com.progressive.kherkin.common.testcore.Then
 import com.progressive.kherkin.common.testcore.When
-import com.progressive.kherkin.compose.steps.actions.IScrollOnNodeUntillISee
-import com.progressive.kherkin.compose.steps.actions.IScrollOnNodeUntillISeeText
+import com.progressive.kherkin.compose.steps.actions.IScrollOnNodeUntilISee
+import com.progressive.kherkin.compose.steps.actions.IScrollOnNodeUntilISeeText
 import com.progressive.kherkin.compose.steps.assertion.IShouldSeeNodeWithText
 import com.progressive.kherkin.compose.steps.setup.IRenderScreen
 import com.progressive.sampleapp.screens.compose.BasicComposeScreen
@@ -16,14 +16,14 @@ class TestScrollSteps : SampleBaseIntegrationTestCase() {
     @Test
     fun testScrollOnNode() {
         Given.IRenderScreen(BasicComposeScreen(), composeTestRule)
-        When.IScrollOnNodeUntillISee("Scroll Box", "Scroll Item 9", composeTestRule)
+        When.IScrollOnNodeUntilISee("Scroll Box", "Scroll Item 9", composeTestRule)
         Then.IShouldSeeNodeWithText("Scroll Item 9", "Scroll item 9", composeTestRule)
     }
 
     @Test
     fun testScrollOnNodeWithText() {
         Given.IRenderScreen(BasicComposeScreen(), composeTestRule)
-        When.IScrollOnNodeUntillISeeText("Scroll Box", "Scroll item 9", composeTestRule)
+        When.IScrollOnNodeUntilISeeText("Scroll Box", "Scroll item 9", composeTestRule)
         Then.IShouldSeeNodeWithText("Scroll Item 9", "Scroll item 9", composeTestRule)
     }
 }


### PR DESCRIPTION
- add the .performImeAction() to IEnterTextIntoField and IClearField in the compose library
- fix two random typos